### PR TITLE
Fix Texture & CanvasTexture constructor parameter

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -17,7 +17,7 @@ import { Material } from './../materials/Material';
 import { ToneMapping, ShadowMapType, CullFace, TextureEncoding } from '../constants';
 import { WebXRManager } from '../renderers/webxr/WebXRManager';
 import { BufferGeometry } from './../core/BufferGeometry';
-import { Texture } from '../textures/Texture';
+import { OffscreenCanvas, Texture } from '../textures/Texture';
 import { Data3DTexture } from '../textures/Data3DTexture';
 import { Vector3 } from '../math/Vector3';
 import { Box3 } from '../math/Box3';
@@ -30,10 +30,6 @@ export interface Renderer {
     render(scene: Object3D, camera: Camera): void;
     setSize(width: number, height: number, updateStyle?: boolean): void;
 }
-
-/** This is only available in worker JS contexts, not the DOM. */
-// tslint:disable-next-line:no-empty-interface
-export interface OffscreenCanvas extends EventTarget {}
 
 export interface WebGLRendererParameters {
     /**

--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -1,6 +1,5 @@
-import { Texture } from './Texture';
+import { OffscreenCanvas, Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '../constants';
-import { OffscreenCanvas } from '../renderers/WebGLRenderer';
 
 export class CanvasTexture extends Texture {
     /**

--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -1,5 +1,6 @@
 import { Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '../constants';
+import { OffscreenCanvas } from '../renderers/WebGLRenderer';
 
 export class CanvasTexture extends Texture {
     /**
@@ -15,7 +16,7 @@ export class CanvasTexture extends Texture {
      * @param [encoding=THREE.LinearEncoding]
      */
     constructor(
-        canvas: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap,
+        canvas: TexImageSource | OffscreenCanvas,
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -11,7 +11,10 @@ import {
     TextureDataType,
     TextureEncoding,
 } from '../constants';
-import { OffscreenCanvas } from '../renderers/WebGLRenderer';
+
+/** Shim for OffscreenCanvas. */
+// tslint:disable-next-line:no-empty-interface
+export interface OffscreenCanvas extends EventTarget {}
 
 export class Texture extends EventDispatcher {
     /**

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -11,6 +11,7 @@ import {
     TextureDataType,
     TextureEncoding,
 } from '../constants';
+import { OffscreenCanvas } from '../renderers/WebGLRenderer';
 
 export class Texture extends EventDispatcher {
     /**
@@ -26,7 +27,7 @@ export class Texture extends EventDispatcher {
      * @param [encoding=THREE.LinearEncoding]
      */
     constructor(
-        image?: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
+        image?: TexImageSource | OffscreenCanvas,
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,


### PR DESCRIPTION
According to [WebGL Specification #5.14](https://registry.khronos.org/webgl/specs/latest/1.0/#5.14):
```
typedef (ImageBitmap or
         ImageData or
         HTMLImageElement or
         HTMLCanvasElement or
         HTMLVideoElement or
         OffscreenCanvas or
         VideoFrame) TexImageSource;
```
So the first parameter of `Texture` & `CanvasTexture`'s constructor should accept more types: `ImageBitmap | ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | OffscreenCanvas`, or `TexImageSource | OffscreenCanvas` in short. (VideoFrame is from Web Codecs API which is still experimental, so left it for the future)